### PR TITLE
Add Dockerfiles for base image

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -15,6 +15,7 @@ RUN apk --no-cache --virtual deps add \
       bash \
       git \
       libpng-dev \
+      nasm \
       autoconf \
       automake \
     && npm install -g \

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,32 @@
+FROM node:8-alpine
+
+LABEL maintainer="etienne@tomochain.com"
+
+ENV HOST 0.0.0.0
+
+WORKDIR /app
+
+COPY client .
+
+RUN apk --no-cache --virtual deps add \
+      python \
+      make \
+      g++ \
+      bash \
+      git \
+      libpng-dev \
+      autoconf \
+      automake \
+    && npm install -g \
+      npm@latest \
+      nuxt \
+      dotenv \
+      node-gyp \
+      pm2 \
+    && npm install \
+    && npm run build \
+    && apk del deps
+
+EXPOSE 3000
+
+ENTRYPOINT ["pm2-docker", "start", "pm2.json", "--only", "prod"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,28 @@
+FROM node:8-alpine
+
+LABEL maintainer="etienne@tomochain.com"
+
+ENV HOST 0.0.0.0
+
+WORKDIR /app
+
+COPY server .
+
+RUN apk --no-cache --virtual deps add \
+      python \
+      make \
+      g++ \
+      bash \
+      git \
+    && npm install -g \
+       npm@latest \
+       dotenv \
+       node-gyp \
+       pm2 \
+    && npm install \
+    && npm run build \
+    && apk del deps
+
+EXPOSE 3333
+
+ENTRYPOINT ["pm2-docker", "start", "pm2.json", "--only", "prod"]


### PR DESCRIPTION
This PR aims to add the two docker base images who will be used by the infrastructure images.
The goal is to separate the application codebase from the environment (localnet, devnet, testnet, prod) specific configuration

For now as only the devnet infrastructure is being built, the other Dockerfiles and docker-compose files are still present to not break anyone workflow.